### PR TITLE
Fix code block formatters to parse multiple code blocks correctly

### DIFF
--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -125,7 +125,7 @@ class Formatter
     marks = []
     index = html.scan(/\[\[\[codeblock(\d+)\]\]\]/).map(&:to_i).max || 0
 
-    html = html.gsub(/^```(?<lang>[^\n]*)\n(?<code>.*)\n```$/m) do |match|
+    html = html.gsub(/^```(?<lang>[^\n]*)\n(?<code>.*?)\n```$/m) do |match|
       lang = $1
       code = $2
       marker = "[[[codeblock#{index += 1}]]]"
@@ -134,7 +134,7 @@ class Formatter
       marker
     end
 
-    html = html.gsub(/`(?<code>[^`\n]+)`/) do |match|
+    html = html.gsub(/`(?<code>[^`\n]+?)`/) do |match|
       code = $1
       marker = "[[[codeblock#{index += 1}]]]"
       block_html = "<code class=\"singleline\">#{ sanitize(code, Sanitize::Config::MASTODON_STRICT) }</code>"

--- a/spec/lib/formatter_spec.rb
+++ b/spec/lib/formatter_spec.rb
@@ -115,10 +115,25 @@ RSpec.describe Formatter do
       end
     end
 
+    context 'contains multiple inline code blocks' do
+      let(:local_text) { "`hoge` `piyo`" }
+      it 'has code block' do
+        expect(subject).to match('<p><code class="singleline">hoge</code> <code class="singleline">piyo</code></p>')
+      end
+    end
+
     context 'contains multi line code block' do
       let(:local_text) { "```ruby\nputs 'Hello, World!'\n```" }
       it 'has code block' do
         expect(subject).to match '<p><pre><code data-language="ruby">puts \'Hello, World!\'</code></pre></p>'
+      end
+    end
+
+    context 'contains multiple code blocks' do
+      let(:local_text) { "```ruby\nputs 'Hello, World!'\n```\n```js\nconsole.log('Hello, World!');\n```" }
+      it 'has code block' do
+        expect(subject).to include('<pre><code data-language="ruby">puts \'Hello, World!\'</code></pre>')
+        expect(subject).to include('<pre><code data-language="js">console.log(\'Hello, World!\');</code></pre>')
       end
     end
   end


### PR DESCRIPTION
This PR fixes the problem that our formatter cannot parse multiple code blocks correctly.

## Before
<img width="331" alt="2017-05-01 22 24 45" src="https://cloud.githubusercontent.com/assets/1477130/25580681/beb19250-2ebd-11e7-8cad-fef8328c4bfa.png">


This toot contains two code blocks, `puts 'Hoge'` and `console.log('Hello')`.
However, our formatter parses these blocks as a block by mistake.

## After
<img width="366" alt="2017-05-01 22 25 32" src="https://cloud.githubusercontent.com/assets/1477130/25580612/562746a8-2ebd-11e7-97a7-612ebc72b2c6.png">

In this figure, our formatter parses these blocks as different blocks.