### PR TITLE
Add docker settings for development environment

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,21 @@
+# Service dependencies
+REDIS_HOST=redis
+REDIS_PORT=6379
+# REDIS_DB=0
+DB_HOST=db
+DB_USER=postgres
+DB_PASS=
+
+# Federation
+LOCAL_DOMAIN=localhost:3000
+LOCAL_HTTPS=false
+
+# Application secrets
+# Generate each with the `rake secret` task (`docker-compose run --rm web rake secret` if you use docker compose)
+PAPERCLIP_SECRET=RANDOM_STRING
+SECRET_KEY_BASE=RANDOM_STRING
+OTP_SECRET=RANDOM_STRING
+
+# Cluster number setting for streaming API server.
+# If you comment out following line, cluster number will be `numOfCpuCores - 1`.
+STREAMING_CLUSTER_NUM=1

--- a/Dockerfile-development
+++ b/Dockerfile-development
@@ -1,0 +1,41 @@
+FROM ruby:2.4.1-alpine
+
+LABEL maintainer="https://github.com/increments/mastodon" \
+      description="A GNU Social-compatible microblogging server"
+
+EXPOSE 3000 4000
+
+WORKDIR /mastodon
+
+RUN echo "@edge https://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
+ && BUILD_DEPS=" \
+    cmake \
+    postgresql-dev \
+    libxml2-dev \
+    libxslt-dev \
+    python \
+    build-base" \
+ && apk -U upgrade && apk add \
+    $BUILD_DEPS \
+    nodejs@edge \
+    nodejs-npm@edge \
+    libpq \
+    libxml2 \
+    libxslt \
+    ffmpeg \
+    file \
+    imagemagick@edge \
+ && rm -rf /tmp/* /var/cache/apk/*
+
+COPY Gemfile Gemfile.lock /mastodon/
+RUN bundle install
+
+COPY package.json yarn.lock /mastodon/
+RUN npm install -g yarn \
+ && yarn --ignore-optional \
+ && yarn cache clean \
+ && npm -g cache clean
+
+COPY . /mastodon
+
+VOLUME /mastodon/public/system /mastodon/public/assets

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,6 +7,9 @@ default: &default
 development:
   <<: *default
   database: mastodon_development
+  username: <%= ENV['DB_USER'] || 'postgres' %>
+  password: <%= ENV['DB_PASS'] || '' %>
+  host: <%= ENV['DB_HOST'] || 'localhost' %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -14,11 +17,14 @@ development:
 test:
   <<: *default
   database: mastodon_test
+  username: <%= ENV['DB_USER'] || 'postgres' %>
+  password: <%= ENV['DB_PASS'] || '' %>
+  host: <%= ENV['DB_HOST'] || 'localhost' %>
 
 production:
   <<: *default
   database: <%= ENV['DB_NAME'] || 'mastodon_production' %>
-  username: <%= ENV['DB_USER'] || 'mastodon' %>
+  username: <%= ENV['DB_USER'] || '' %>
   password: <%= ENV['DB_PASS'] || '' %>
   host: <%= ENV['DB_HOST'] || 'localhost' %>
   port: <%= ENV['DB_PORT'] || 5432 %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -79,7 +79,4 @@ Rails.application.configure do
   config.react.variant = :development
 end
 
-require 'sidekiq/testing'
-Sidekiq::Testing.inline!
-
 ActiveRecordQueryTrace.enabled = ENV.fetch('QUERY_TRACE_ENABLED') { false }

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,0 +1,73 @@
+version: '2'
+services:
+
+  db:
+    restart: always
+    image: postgres:alpine
+    volumes:
+      - ./postgres:/var/lib/postgresql/data
+
+  redis:
+    restart: always
+    image: redis:alpine
+    volumes:
+      - ./redis:/data
+
+  web:
+    restart: always
+    build: &build
+      context: ..
+      dockerfile: Dockerfile-development
+    image: mastodon-development
+    env_file: .env
+    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+      - redis
+    volumes: &app
+      - ./.rspec:/mastodon/.rspec
+      - ./.rubocop.yml:/mastodon/.rubocop.yml
+      - ./.ruby-version:/mastodon/.ruby-version
+      - ./.yardopts:/mastodon/.yardopts
+      - ./app:/mastodon/app
+      - ./bin:/mastodon/bin
+      - ./config:/mastodon/config
+      - ./config.ru:/mastodon/config.ru
+      - ./db:/mastodon/db
+      - ./docs:/mastodon/docs
+      - ./Gemfile:/mastodon/Gemfile
+      - ./Gemfile.lock:/mastodon/Gemfile.lock
+      - ./lib:/mastodon/lib
+      - ./public:/mastodon/public
+      - ./spec:/mastodon/spec
+      - ./storybook:/mastodon/storybook
+      - ./streaming:/mastodon/streaming
+      - ./vendor/assets:/mastodon/vendor/assets
+
+
+  streaming:
+    restart: always
+    build: *build
+    image: mastodon-development
+    ports:
+      - "4000:4000"
+    env_file: .env
+    command: npm run start
+    ports:
+      - "4000:4000"
+    depends_on:
+      - db
+      - redis
+
+  sidekiq:
+    restart: always
+    build: *build
+    image: mastodon-development
+    env_file: .env
+    command: bundle exec sidekiq -q default -q mailers -q pull -q push
+    depends_on:
+      - db
+      - redis
+    volumes: *app

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -36,7 +36,10 @@ if (cluster.isMaster) {
   const pgConfigs = {
     development: {
       database: 'mastodon_development',
-      host:     '/var/run/postgresql',
+      user:     process.env.DB_USER || 'mastodon',
+      password: process.env.DB_PASS || '',
+      host:     process.env.DB_HOST || 'localhost',
+      port:     process.env.DB_PORT || 5432,
       max:      10
     },
 


### PR DESCRIPTION
Development 環境でもDockerを使って開発が行えるようにします。
またSidekiqが Development 環境で簡略化されている設定も無効にします。

## 準備

`.env.sample` に `.env` のテンプレートがあるので、これを元に `.env` を作成してください。
`RANDOM_STRING` は適当な文字列に置き換えてください。

```
docker-compose -f docker-compose.development.yml build
docker-compose -f docker-compose.development.yml run web bundle exec rails db:setup
```

## 起動

開発用には `docker-compose.development.yml` を利用します。 (`docker-compose.yml` は本番用です)

```
docker-compose -f docker-compose.development.yml up # 起動する場合
docker-compose -f docker-compose.development.yml build #  Gemfile等を更新した場合
docker-compose -f docker-compose.development.yml run SERVICE_NAME COMMAND # コマンドをDockerコンテナ内で実行したい場合 
```

## Tips
### メール

Development環境のメールの認証は letter_opener ( http://localhost:3000/letter_opener ) か rake コマンドを使って行います。

### Pull Request する場合の指定先

Pull Request先があってるか(increments/mastodon のincrementsブランチになってるか)注意してください。間違ったら本家に飛んでしまいます。
<img width="476" alt="2017-05-03 13 56 57" src="https://cloud.githubusercontent.com/assets/1477130/25648720/f6b07980-3009-11e7-81e9-7507468a4c68.png">


