### PR TITLE
Fix urls and image character urls

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -2760,7 +2760,7 @@ button.icon-button.active i.fa-retweet {
 }
 
 .onboarding-modal__page-one__elephant-friend {
-  background: image-url('elephant-friend.png') no-repeat center center/contain;
+  background: image-url('qiitan.png') no-repeat center center/contain;
   width: 147px;
   height: 160px;
   margin-right: 10px;

--- a/app/views/about/_links.html.haml
+++ b/app/views/about/_links.html.haml
@@ -9,4 +9,4 @@
           %li= link_to t('about.get_started'), new_user_registration_path
         %li= link_to t('auth.login'), new_user_session_path
       %li= link_to t('about.terms'), terms_path
-      %li= link_to t('about.source_code'), 'https://github.com/tootsuite/mastodon'
+      %li= link_to t('about.source_code'), 'https://github.com/increments/mastodon'

--- a/app/views/about/show.html.haml
+++ b/app/views/about/show.html.haml
@@ -82,6 +82,6 @@
       ·
       = link_to t('about.apps'), 'https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/Apps.md'
       ·
-      = link_to t('about.source_code'), 'https://github.com/tootsuite/mastodon'
+      = link_to t('about.source_code'), 'https://github.com/increments/mastodon'
       ·
       = link_to t('about.other_instances'), 'https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/List-of-Mastodon-instances.md'


### PR DESCRIPTION
初回の説明時のキャラクター画像をQiitanに変更した。

<img width="668" alt="2017-05-19 0 41 50" src="https://cloud.githubusercontent.com/assets/1477130/26210995/4dc0a5b4-3c2c-11e7-8d7b-0fd2bf02bb11.png">

サーバー情報等のページのソースコードの参照先を increments/mastodon に変更した。