### PR TITLE
Send error reports to Sentry

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -90,3 +90,5 @@ SMTP_FROM_ADDRESS=notifications@example.com
 # Cluster number setting for streaming API server.
 # If you comment out following line, cluster number will be `numOfCpuCores - 1`.
 STREAMING_CLUSTER_NUM=1
+
+SENTRY_DSN=

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem 'redis', '~>3.2', require: ['redis', 'redis/connection/hiredis']
 gem 'rqrcode'
 gem 'ruby-oembed', require: 'oembed'
 gem 'sanitize'
+gem 'sentry-raven'
 gem 'sidekiq'
 gem 'sidekiq-scheduler'
 gem 'sidekiq-unique-jobs'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,8 @@ GEM
     fabrication (2.16.1)
     faker (1.7.3)
       i18n (~> 0.5)
+    faraday (0.12.1)
+      multipart-post (>= 1.2, < 3)
     fast_blank (1.0.0)
     font-awesome-rails (4.7.0.1)
       railties (>= 3.2, < 5.1)
@@ -256,6 +258,7 @@ GEM
     mimemagic (0.3.2)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
+    multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.1.0)
@@ -418,6 +421,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sentry-raven (2.4.0)
+      faraday (>= 0.7.6, < 1.0)
     sidekiq (4.2.10)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
@@ -560,6 +565,7 @@ DEPENDENCIES
   ruby-oembed
   sanitize
   sass-rails (~> 5.0)
+  sentry-raven
   sidekiq
   sidekiq-scheduler
   sidekiq-unique-jobs

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,0 +1,4 @@
+Raven.configure do |config|
+  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+  config.environments = %w(staging production)
+end


### PR DESCRIPTION
送信先は環境変数 `SENTRY_DSN` で設定する。