### PR TITLE
Fix a bug that code in toots are doubly HTML escaped

### DIFF
--- a/app/assets/javascripts/components/highlight-code.js
+++ b/app/assets/javascripts/components/highlight-code.js
@@ -7,7 +7,7 @@ export default function highlightCode(text) {
     doc.querySelectorAll('code').forEach((el) => {
       el.classList.add('hljs');
       if (el.dataset.language && !el.dataset.highlighted) {
-        el.innerHTML = hljs.highlight(el.dataset.language, el.innerHTML).value;
+        el.innerHTML = hljs.highlight(el.dataset.language, el.innerText).value;
         el.dataset.highlighted = true;
       }
     })


### PR DESCRIPTION
# Before
<img width="337" alt="2017-05-24 15 01 40" src="https://cloud.githubusercontent.com/assets/1477130/26388888/ed530b1c-4091-11e7-8774-9660a23ab763.png">

# After
<img width="329" alt="2017-05-24 15 01 33" src="https://cloud.githubusercontent.com/assets/1477130/26388896/f680e9b6-4091-11e7-8723-6de18e520fea.png">
