### PR TITLE
Fix code highlight

### DIFF
--- a/app/assets/javascripts/application_public.js
+++ b/app/assets/javascripts/application_public.js
@@ -6,4 +6,9 @@
 
 $(function () {
   $(".best_in_place").best_in_place();
+
+  const highlightCode = require('./components/highlight-code').default;
+  $("code").each((idx, el) => {
+    el.outerHTML = highlightCode(el.outerHTML);
+  });
 });

--- a/app/lib/code_block_formatter.rb
+++ b/app/lib/code_block_formatter.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module CodeBlockFormatter
+  MULTILINE_CODEBLOCK_REGEXP = /^```(?<language>[^:\n]*)\n(?<code>.*?)\n```$/m
+  INLINE_CODEBLOCK_REGEXP = /`(?<code>[^`\n]+?)`/
+
+  module_function
+
+  def swap_code_literal_to_marker(html)
+    marker_and_contents = []
+    index = html.scan(/\[\[\[codeblock(\d+)\]\]\]/).map(&:to_i).max || 0
+
+    html = html.gsub(MULTILINE_CODEBLOCK_REGEXP) do
+      match_data = Regexp.last_match
+      language = sanitize(match_data[:language], Sanitize::Config::MASTODON_STRICT).gsub(/["']/, '')
+      code = sanitize(match_data[:code], Sanitize::Config::MASTODON_STRICT)
+
+      marker = "[[[codeblock#{index += 1}]]]"
+      block_html = "<pre><code#{ language.present? ? " data-language=\"#{ language }\"" : '' }>#{ code }</code></pre>"
+      marker_and_contents << [marker, block_html]
+      marker
+    end
+
+    html = html.gsub(INLINE_CODEBLOCK_REGEXP) do |match|
+      match_data = Regexp.last_match
+      code = sanitize(match_data[:code], Sanitize::Config::MASTODON_STRICT)
+
+      marker = "[[[codeblock#{index += 1}]]]"
+      block_html = "<code class=\"inline\">#{ code }</code>"
+      marker_and_contents << [marker, block_html]
+      marker
+    end
+
+    [html, marker_and_contents]
+  end
+
+  def swap_marker_to_code_blocks(html, marker_and_contents)
+    marker_and_contents.reverse.reduce(html) do |html, (marker, block_html)|
+      html.gsub(marker, block_html)
+    end
+  end
+
+  def sanitize(html, config)
+    Sanitize.fragment(html, config)
+  end
+end

--- a/app/lib/code_block_formatter.rb
+++ b/app/lib/code_block_formatter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module CodeBlockFormatter
-  MULTILINE_CODEBLOCK_REGEXP = /^```(?<language>[^:\n]*)\n(?<code>.*?)\n```$/m
+  MULTILINE_CODEBLOCK_REGEXP = /^```(?<language>[^:\n]*)(?::(?<filename>[^\n]*))?\n(?<code>.*?)\n```$/m
   INLINE_CODEBLOCK_REGEXP = /`(?<code>[^`\n]+?)`/
 
   module_function
@@ -13,10 +13,11 @@ module CodeBlockFormatter
     html = html.gsub(MULTILINE_CODEBLOCK_REGEXP) do
       match_data = Regexp.last_match
       language = sanitize(match_data[:language], Sanitize::Config::MASTODON_STRICT).gsub(/["']/, '')
+      filename = sanitize(match_data[:filename] || '', Sanitize::Config::MASTODON_STRICT).gsub(/["']/, '')
       code = sanitize(match_data[:code], Sanitize::Config::MASTODON_STRICT)
 
       marker = "[[[codeblock#{index += 1}]]]"
-      block_html = "<pre><code#{ language.present? ? " data-language=\"#{ language }\"" : '' }>#{ code }</code></pre>"
+      block_html = "<pre><code#{ language.present? ? " data-language=\"#{ language }\"" : '' }#{ filename.present? ? " data-filename=\"#{ filename }\"" : '' }>#{ code }</code></pre>"
       marker_and_contents << [marker, block_html]
       marker
     end

--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -14,12 +14,12 @@ class Formatter
 
     html = status.text
     html = encode_and_link_urls(html)
-    html, marks = swap_code_literal_to_marker(html)
+    html, marks = CodeBlockFormatter.swap_code_literal_to_marker(html)
     html = simple_format(html, {}, sanitize: false)
     html = html.delete("\n")
     html = link_mentions(html, status.mentions)
     html = link_hashtags(html)
-    html = swap_marker_to_code_blocks(html, marks)
+    html = CodeBlockFormatter.swap_marker_to_code_blocks(html, marks)
 
     html.html_safe # rubocop:disable Rails/OutputSafety
   end
@@ -119,35 +119,5 @@ class Formatter
 
   def mention_html(match, account)
     "#{match.split('@').first}<span class=\"h-card\"><a href=\"#{TagManager.instance.url_for(account)}\" class=\"u-url mention\">@<span>#{account.username}</span></a></span>"
-  end
-
-  def swap_code_literal_to_marker(html)
-    marks = []
-    index = html.scan(/\[\[\[codeblock(\d+)\]\]\]/).map(&:to_i).max || 0
-
-    html = html.gsub(/^```(?<lang>[^\n]*)\n(?<code>.*?)\n```$/m) do |match|
-      lang = $1
-      code = $2
-      marker = "[[[codeblock#{index += 1}]]]"
-      block_html = "<pre><code #{ lang ? "data-language=\"#{ sanitize(lang, Sanitize::Config::MASTODON_STRICT).gsub(/["']/, '') }\"" : "" }>#{ sanitize(code, Sanitize::Config::MASTODON_STRICT) }</code></pre>"
-      marks << [marker, block_html]
-      marker
-    end
-
-    html = html.gsub(/`(?<code>[^`\n]+?)`/) do |match|
-      code = $1
-      marker = "[[[codeblock#{index += 1}]]]"
-      block_html = "<code class=\"inline\">#{ sanitize(code, Sanitize::Config::MASTODON_STRICT) }</code>"
-      marks << [marker, block_html]
-      marker
-    end
-
-    [html, marks]
-  end
-
-  def swap_marker_to_code_blocks(html, marks)
-    marks.reverse.reduce(html) do |html, (marker, block_html)|
-      html.gsub(marker, block_html)
-    end
   end
 end

--- a/spec/lib/formatter_spec.rb
+++ b/spec/lib/formatter_spec.rb
@@ -129,6 +129,13 @@ RSpec.describe Formatter do
       end
     end
 
+    context 'contains multi line code block with filename' do
+      let(:local_text) { "```ruby:hello.rb\nputs 'Hello, World!'\n```" }
+      it 'has code block' do
+        expect(subject).to match '<p><pre><code data-language="ruby" data-filename="hello.rb">puts \'Hello, World!\'</code></pre></p>'
+      end
+    end
+
     context 'contains multiple code blocks' do
       let(:local_text) { "```ruby\nputs 'Hello, World!'\n```\n```js\nconsole.log('Hello, World!');\n```" }
       it 'has code block' do


### PR DESCRIPTION
- コードブロックで `syntax:filename` を渡されたときに対応
- Toot pageでもハイライトするようにした