### PR TITLE
Does not use pre tag for code blocks

### DIFF
--- a/app/assets/javascripts/components/highlight-code.js
+++ b/app/assets/javascripts/components/highlight-code.js
@@ -12,12 +12,6 @@ export default function highlightCode(text) {
       }
     });
 
-    [].forEach.call(doc.querySelectorAll('p'), (el) => {
-      if (el.innerHTML.length === 0) {
-        el.remove();
-      }
-    });
-
     return doc.body.innerHTML;
   } catch(e) {
     return text;

--- a/app/assets/javascripts/components/highlight-code.js
+++ b/app/assets/javascripts/components/highlight-code.js
@@ -1,4 +1,4 @@
-import hljs from 'highlight.js';
+import { highlight } from 'highlight.js';
 
 export default function highlightCode(text) {
   try {
@@ -7,8 +7,12 @@ export default function highlightCode(text) {
     [].forEach.call(doc.querySelectorAll('code'), (el) => {
       el.classList.add('hljs');
       if (el.dataset.language && !el.dataset.highlighted) {
-        el.innerHTML = hljs.highlight(el.dataset.language, el.innerText).value;
-        el.dataset.highlighted = true;
+        try {
+          el.innerHTML = highlight(el.dataset.language, el.innerText).value;
+          el.dataset.highlighted = true;
+        } catch(e) {
+          // unsupported syntax for highlight.js
+        }
       }
     });
 

--- a/app/assets/stylesheets/code.scss
+++ b/app/assets/stylesheets/code.scss
@@ -4,6 +4,7 @@ code.hljs {
   border-radius: 2px;
   font-size: 12px;
   line-height: 1.2;
+  white-space: pre;
 
   &.inline {
     display: inline;

--- a/app/lib/code_block_formatter.rb
+++ b/app/lib/code_block_formatter.rb
@@ -14,12 +14,12 @@ module CodeBlockFormatter
       match_data = Regexp.last_match
       language = sanitize(match_data[:language], Sanitize::Config::MASTODON_STRICT).gsub(/["']/, '')
       filename = sanitize(match_data[:filename] || '', Sanitize::Config::MASTODON_STRICT).gsub(/["']/, '')
-      code = sanitize(match_data[:code], Sanitize::Config::MASTODON_STRICT)
+      code = sanitize(match_data[:code], Sanitize::Config::MASTODON_STRICT).split("\n").join("<br>")
 
       marker = "[[[codeblock#{index += 1}]]]"
-      block_html = "<pre><code#{ language.present? ? " data-language=\"#{ language }\"" : '' }#{ filename.present? ? " data-filename=\"#{ filename }\"" : '' }>#{ code }</code></pre>"
+      block_html = "<code#{ language.present? ? " data-language=\"#{ language }\"" : '' }#{ filename.present? ? " data-filename=\"#{ filename }\"" : '' }>#{ code }</code>"
       marker_and_contents << [marker, block_html]
-      marker
+      "\n#{marker}\n"
     end
 
     html = html.gsub(INLINE_CODEBLOCK_REGEXP) do |match|
@@ -27,7 +27,7 @@ module CodeBlockFormatter
       code = sanitize(match_data[:code], Sanitize::Config::MASTODON_STRICT)
 
       marker = "[[[codeblock#{index += 1}]]]"
-      block_html = "<code class=\"inline\">#{ code }</code>"
+      block_html = "<span><code class=\"inline\">#{ code }</code></span>"
       marker_and_contents << [marker, block_html]
       marker
     end
@@ -37,7 +37,7 @@ module CodeBlockFormatter
 
   def swap_marker_to_code_blocks(html, marker_and_contents)
     marker_and_contents.reverse.reduce(html) do |html, (marker, block_html)|
-      html.gsub(marker, block_html)
+      html.sub(marker, block_html)
     end
   end
 

--- a/spec/lib/formatter_spec.rb
+++ b/spec/lib/formatter_spec.rb
@@ -108,39 +108,41 @@ RSpec.describe Formatter do
       end
     end
 
-    context 'contains single line code block' do
-      let(:local_text) { "`program`" }
-      it 'has code block' do
-        expect(subject).to match '<p><code class="inline">program</code></p>'
+    describe 'code block' do
+      context 'contains single line code block' do
+        let(:local_text) { "`program`" }
+        it 'has code block' do
+          expect(subject).to match '<span><code class="inline">program</code></span>'
+        end
       end
-    end
 
-    context 'contains multiple inline code blocks' do
-      let(:local_text) { "`hoge` `piyo`" }
-      it 'has code block' do
-        expect(subject).to match('<p><code class="inline">hoge</code> <code class="inline">piyo</code></p>')
+      context 'contains multiple inline code blocks' do
+        let(:local_text) { "`hoge` `piyo`" }
+        it 'has code block' do
+          expect(subject).to match('<span><code class="inline">hoge</code></span> <span><code class="inline">piyo</code></span>')
+        end
       end
-    end
 
-    context 'contains multi line code block' do
-      let(:local_text) { "```ruby\nputs 'Hello, World!'\n```" }
-      it 'has code block' do
-        expect(subject).to match '<p><pre><code data-language="ruby">puts \'Hello, World!\'</code></pre></p>'
+      context 'contains multi line code block' do
+        let(:local_text) { "```ruby\nputs 'Hello, World!'\n```" }
+        it 'has code block' do
+          expect(subject).to match '<p><code data-language="ruby">puts \'Hello, World!\'</code></p>'
+        end
       end
-    end
 
-    context 'contains multi line code block with filename' do
-      let(:local_text) { "```ruby:hello.rb\nputs 'Hello, World!'\n```" }
-      it 'has code block' do
-        expect(subject).to match '<p><pre><code data-language="ruby" data-filename="hello.rb">puts \'Hello, World!\'</code></pre></p>'
+      context 'contains multi line code block with filename' do
+        let(:local_text) { "```ruby:hello.rb\nputs 'Hello, World!'\n```" }
+        it 'has code block' do
+          expect(subject).to match '<p><code data-language="ruby" data-filename="hello.rb">puts \'Hello, World!\'</code></p>'
+        end
       end
-    end
 
-    context 'contains multiple code blocks' do
-      let(:local_text) { "```ruby\nputs 'Hello, World!'\n```\n```js\nconsole.log('Hello, World!');\n```" }
-      it 'has code block' do
-        expect(subject).to include('<pre><code data-language="ruby">puts \'Hello, World!\'</code></pre>')
-        expect(subject).to include('<pre><code data-language="js">console.log(\'Hello, World!\');</code></pre>')
+      context 'contains multiple code blocks' do
+        let(:local_text) { "```ruby\nputs 'Hello, World!'\n```\n```js\nconsole.log('Hello, World!');\n```" }
+        it 'has code block' do
+          expect(subject).to include('<p><code data-language="ruby">puts \'Hello, World!\'</code></p>')
+          expect(subject).to include('<p><code data-language="js">console.log(\'Hello, World!\');</code></p>')
+        end
       end
     end
   end


### PR DESCRIPTION
コードブロックでpreタグを使うのをやめて、アプリや他のインスタンスで表示した際に崩れないようにした。