### PR TITLE
Fix code highlighter not to delete line breaks for Firefox

### DIFF
--- a/app/assets/javascripts/components/highlight-code.js
+++ b/app/assets/javascripts/components/highlight-code.js
@@ -8,7 +8,7 @@ export default function highlightCode(text) {
       el.classList.add('hljs');
       if (el.dataset.language && !el.dataset.highlighted) {
         try {
-          el.innerHTML = highlight(el.dataset.language, el.innerText).value;
+          el.innerHTML = highlight(el.dataset.language, getTextContent(el)).value;
           el.dataset.highlighted = true;
         } catch(e) {
           // unsupported syntax for highlight.js
@@ -21,3 +21,9 @@ export default function highlightCode(text) {
     return text;
   }
 };
+
+function getTextContent(el) {
+  const contentEl = document.createElement('div');
+  contentEl.innerHTML = el.innerHTML.replace(/<br\s*\/?>/g, "\n");
+  return contentEl.textContent;
+}


### PR DESCRIPTION
Firefoxでコードハイライトするとコードの改行が消えてしまっていたので修正した。