### PR TITLE
To make wider the last div of columns-area

### DIFF
--- a/app/javascript/styles/themes.scss
+++ b/app/javascript/styles/themes.scss
@@ -5,3 +5,11 @@ body.theme-light {
 body.theme-dark {
   @import 'theme-dark';
 }
+
+@media screen and (min-width: 1025px) {
+  .columns-area>div:last-child>.column,
+  .mastodon-column-container>.column {
+    flex: 1;
+    max-width: 640px;
+  }
+}


### PR DESCRIPTION
Close https://github.com/increments/mastodon/issues/30

## What
画面に余裕のある場合に、ローカルタイムラインや連合タイムラインが表示されるカラムの幅を広くとるように変更する。

## Why
デフォルトのカラム幅だとコードブロックを閲覧するには狭く視認性が低いため。

## How
右端のカラムを残りの画面幅分（最大640pxまで）拡張する。
特定のトゥートをクリックすればこのカラムに表示されるため、初動としては必要十分な対応。

![image](https://cloud.githubusercontent.com/assets/732828/26577942/11092164-4569-11e7-8124-932ce384421e.png)

## Thx @VoQn
今回は、基本的に以下のコードを引用させていただく形で実装しました :pray:
https://qiitadon.com/@voqn/742