### PR TITLE
Fix broken Qiita account name snippet

### DIFF
--- a/app/javascript/mastodon/features/account/components/header.js
+++ b/app/javascript/mastodon/features/account/components/header.js
@@ -129,8 +129,9 @@ class Header extends ImmutablePureComponent {
           <Avatar account={account} autoPlayGif={this.props.autoPlayGif} />
 
           <span className='account__header__display-name' dangerouslySetInnerHTML={displayNameHTML} />
-          <span className='account__header__usernames' style={{ display: 'block', marginBottom: '10px' }} >
+          <span className='account__header__usernames'>
             <span className='account__header__username'>@{account.get('acct')} {lockedIcon}</span>
+            { this.renderQiitaUsername() }
           </span>
           <div className='account__header__content' dangerouslySetInnerHTML={content} />
 

--- a/app/javascript/styles/accounts.scss
+++ b/app/javascript/styles/accounts.scss
@@ -403,23 +403,3 @@
     color: $ui-base-color;
   }
 }
-
-.account__header__qiita--username:before {
-  content: ' ';
-  display: inline-block;
-  height: 14px;
-  width: 14px;
-  vertical-align: middle;
-  background: image-url('qiita-icon.png');
-  background-size: 14px;
-  margin: 0 2px;
-}
-
-.account__header__qiita--username a {
-  text-decoration: none;
-  color: inherit;
-
-  &:hover {
-    text-decoration: underline;
-  }
-}

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -854,12 +854,37 @@
     font-weight: 500;
   }
 
+  .account__header__usernames {
+    display: block;
+    margin-bottom: 10px;
+  }
+
   .account__header__username {
     color: $ui-highlight-color;
     font-size: 14px;
     font-weight: 400;
-    display: block;
+    display: inline;
     margin-bottom: 10px;
+  }
+
+  .account__header__qiita--username:before {
+    content: ' ';
+    display: inline-block;
+    height: 14px;
+    width: 14px;
+    vertical-align: middle;
+    background: url('../images/qiita-icon.png');
+    background-size: 14px;
+    margin: 0 2px;
+  }
+
+  .account__header__qiita--username a {
+    text-decoration: none;
+    color: inherit;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 }
 


### PR DESCRIPTION
Qiitaアカウントネームを表示するやつが表示されなくなってしまったので直した。
<img width="198" alt="2017-05-31 16 43 20" src="https://cloud.githubusercontent.com/assets/1477130/26621060/4a9c2586-4620-11e7-9c6a-d4d721d56c63.png">
