### PR TITLE
Using custom.scss

### DIFF
--- a/app/javascript/packs/custom.js
+++ b/app/javascript/packs/custom.js
@@ -1,0 +1,1 @@
+import '../styles/custom.scss';

--- a/app/javascript/styles/application.scss
+++ b/app/javascript/styles/application.scss
@@ -19,8 +19,3 @@
 @import 'tables';
 @import 'admin';
 @import 'rtl';
-
-@import 'themes';
-@import 'alert';
-@import 'code';
-@import 'qiita';

--- a/app/javascript/styles/custom.scss
+++ b/app/javascript/styles/custom.scss
@@ -1,0 +1,5 @@
+@import 'application';
+@import 'themes';
+@import 'alert';
+@import 'code';
+@import 'qiita';

--- a/app/javascript/styles/theme-dark.scss
+++ b/app/javascript/styles/theme-dark.scss
@@ -165,6 +165,11 @@ $accent-border-color: #444;
   border-top-right-radius: 2px;
 }
 
+.column-collapsable .column-collapsable__button {
+  @extend %accent-box-styles;
+  border: 0;
+}
+
 .collapsable:hover {
   background-color: transparent;
 }

--- a/app/javascript/styles/theme-light.scss
+++ b/app/javascript/styles/theme-light.scss
@@ -1,6 +1,6 @@
 @import '../../../node_modules/highlight.js/styles/github';
 
-// Dark theme colors
+// Light theme colors
 
 $text-color: #333;
 $sub-text-color: #aaa;
@@ -164,6 +164,11 @@ $accent-border-color: #52b03b;
   background-color: transparent;
   color: $accent-sub-text-color;
   border-top-right-radius: 2px;
+}
+
+.column-collapsable .column-collapsable__button {
+  @extend %accent-box-styles;
+  border: 0;
 }
 
 .collapsable:hover {


### PR DESCRIPTION
`custom.scss`を使って本家とのコンフリクトが起き難いようにしました。

実際は[`variables.scss`](https://github.com/tootsuite/mastodon/blob/v1.4.1/app/javascript/styles/variables.scss)の値を上書きするほうが良いのですが、それをするとテーマ切り替えができなくなってしまうので、`custom.scss`の導入だけにしています。

あとおまけで #55 も直っています。
