### PR TITLE
Fix a bug that code including `\1` cannot be displayed as expected

### DIFF
--- a/app/lib/code_block_formatter.rb
+++ b/app/lib/code_block_formatter.rb
@@ -37,7 +37,7 @@ module CodeBlockFormatter
 
   def swap_marker_to_code_blocks(html, marker_and_contents)
     marker_and_contents.reverse.reduce(html) do |html, (marker, block_html)|
-      html.sub(marker, block_html)
+      html.sub(marker) { block_html }
     end
   end
 

--- a/spec/lib/formatter_spec.rb
+++ b/spec/lib/formatter_spec.rb
@@ -194,6 +194,13 @@ RSpec.describe Formatter do
           expect(subject).to include('<p><code data-language="js">console.log(\'Hello, World!\');</code></p>')
         end
       end
+
+      context 'contains capture literals in code block' do
+        let(:local_text) { '`\1`' }
+        it 'has code block' do
+          expect(subject).to include('<span><code class="inline">\1</code></span>')
+        end
+      end
     end
 
     context 'contains invalid URL' do


### PR DESCRIPTION
# What

`\1` などの一部の記法を含んだ文字列がコード記法に含まれる場合に正しく表示できない不具合を修正した。

![2017-06-09 13 55 12](https://user-images.githubusercontent.com/1477130/26961646-4bd7dec0-4d1b-11e7-843b-1b76a010c82b.png)

コード記法を装飾する際に String#sub を使って文字列を置換する処理を行っているが、第2引数に置換後の文字列を渡した場合、一部の文字列を置き換えてしまうのが不具合の原因。

https://docs.ruby-lang.org/ja/latest/method/String/i/sub.html


# Ref
#59