### PR TITLE
Ignore hashtags and mentions in code blocks

### DIFF
--- a/app/lib/code_block_formatter.rb
+++ b/app/lib/code_block_formatter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative './sanitize_config'
+
 module CodeBlockFormatter
   MULTILINE_CODEBLOCK_REGEXP = /^```(?<language>[^:\n]*)(?::(?<filename>[^\n]*))?\n(?<code>.*?)\n```$/m
   INLINE_CODEBLOCK_REGEXP = /`(?<code>[^`\n]+?)`/
@@ -33,6 +35,13 @@ module CodeBlockFormatter
     end
 
     [html, marker_and_contents]
+  end
+
+  def remove_code_blocks(html)
+    html, marker_and_contents = swap_code_literal_to_marker(html)
+    marker_and_contents.reverse.reduce(html) do |html, (marker, block_html)|
+      html.sub(marker) { ' ' }
+    end
   end
 
   def swap_marker_to_code_blocks(html, marker_and_contents)

--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -26,8 +26,8 @@ class Formatter
 
     html = raw_content
     html = "RT @#{prepend_reblog} #{html}" if prepend_reblog
-    html = encode_and_link_urls(html, linkable_accounts)
     html, marks = CodeBlockFormatter.swap_code_literal_to_marker(html)
+    html = encode_and_link_urls(html, linkable_accounts)
     html = simple_format(html, {}, sanitize: false)
     html = html.delete("\n")
     html = CodeBlockFormatter.swap_marker_to_code_blocks(html, marks)

--- a/app/services/process_hashtags_service.rb
+++ b/app/services/process_hashtags_service.rb
@@ -2,7 +2,8 @@
 
 class ProcessHashtagsService < BaseService
   def call(status, tags = [])
-    tags = Extractor.extract_hashtags(status.text) if status.local?
+    sanitized_text = CodeBlockFormatter.remove_code_blocks(status.text)
+    tags = Extractor.extract_hashtags(sanitized_text) if status.local?
 
     tags.map { |str| str.mb_chars.downcase }.uniq(&:to_s).each do |tag|
       status.tags << Tag.where(name: tag).first_or_initialize(name: tag)

--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -10,7 +10,8 @@ class ProcessMentionsService < BaseService
   def call(status)
     return unless status.local?
 
-    status.text.scan(Account::MENTION_RE).each do |match|
+    sanitized_text = CodeBlockFormatter.remove_code_blocks(status.text)
+    sanitized_text.scan(Account::MENTION_RE).each do |match|
       username, domain  = match.first.split('@')
       mentioned_account = Account.find_remote(username, domain)
 

--- a/spec/lib/formatter_spec.rb
+++ b/spec/lib/formatter_spec.rb
@@ -220,6 +220,37 @@ RSpec.describe Formatter do
             expect(subject).to include('<span><code class="inline">hi</code></span>')
           end
         end
+
+        context 'contains a mention literal in the code block' do
+          let(:status) { Fabricate(:status, mentions: [ Fabricate(:mention, account: local_account) ], text: local_text) }
+          let(:local_text) { '@alice `@alice`' }
+
+          before { local_account }
+
+          it 'has code block and its mention is raw text' do
+            expect(subject).to include('<span><code class="inline">@alice</code></span>')
+          end
+        end
+
+        context 'contains a hashtag in the code block' do
+          let(:local_text) { '`#ruby`' }
+
+          before { local_account }
+
+          it 'has code block and its mention is raw text' do
+            expect(subject).to include('<span><code class="inline">#ruby</code></span>')
+          end
+        end
+
+        context 'contains a link in the code block' do
+          let(:local_text) { '`http://example.com`' }
+
+          before { local_account }
+
+          it 'has code block and its link is raw text' do
+            expect(subject).to include('<span><code class="inline">http://example.com</code></span>')
+          end
+        end
       end
 
       context do

--- a/spec/services/process_hashtags_service_spec.rb
+++ b/spec/services/process_hashtags_service_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe ProcessMentionsService do
+  let(:account)     { Fabricate(:account, username: 'alice') }
+  let(:tag)         { Fabricate(:tag) }
+  let(:status)      { Fabricate(:status, account: account, text: text) }
+
+  subject { ProcessHashtagsService.new }
+
+  before do
+    subject.(status)
+  end
+
+  context 'when the status contains a hashtag' do
+    let(:text) { "Hello, world! ##{tag.name}" }
+
+    it 'associates the hashtag with the status' do
+      expect(status.reload.tags).to contain_exactly(tag)
+    end
+  end
+
+  context 'when the status contains a code block' do
+    context 'and the code blcok contains a mention' do
+      let(:text) { "Hello, world! `##{tag.name}`" }
+
+      it 'does not associate the hashtag with the status' do
+        expect(status.reload.tags).to be_empty
+      end
+    end
+  end
+end

--- a/spec/services/process_mentions_service_spec.rb
+++ b/spec/services/process_mentions_service_spec.rb
@@ -19,4 +19,17 @@ RSpec.describe ProcessMentionsService do
   it 'posts to remote user\'s Salmon end point' do
     expect(a_request(:post, remote_user.salmon_url)).to have_been_made
   end
+
+  context 'when the status contains a code block' do
+    let(:status)      { Fabricate(:status, account: account, text: text) }
+
+    context 'and the code blcok contains a mention' do
+      let(:text) { "Hello `@#{remote_user.acct}`" }
+
+      it 'does not create a mention' do
+        expect(a_request(:post, remote_user.salmon_url)).not_to have_been_made
+        expect(status.reload.mentions).to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
コードブロック内のハッシュタグとメンション記法を無視するようにする。