### PR TITLE
Do not run CircleCI build except for deploy branches

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,11 @@
 machine:
   services:
     - docker
+general:
+  branches:
+    only:
+      - qiitadon
+      - increments-mastodon
 database:
   override:
     - echo "Skip database phase"


### PR DESCRIPTION
本番用ブランチ (`qiitadon`, `increments-mastodon`) のみでCIrcleCIでビルドが走るようにした。