### PR TITLE
Exclude `OpenSSL::SSL::SSLError` exception

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,6 +1,6 @@
 Raven.configure do |config|
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
   config.environments = %w(staging production)
-  config.excluded_exceptions += ['OpenSSL::SSL::SSLError']
+  config.excluded_exceptions += ['OpenSSL::SSL::SSLError', 'Mastodon::UnexpectedResponseError', 'HTTP::TimeoutError', 'HTTP::ConnectionError']
 end
 

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,4 +1,6 @@
 Raven.configure do |config|
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
   config.environments = %w(staging production)
+  config.excluded_exceptions += ['OpenSSL::SSL::SSLError']
 end
+


### PR DESCRIPTION
# WHAT
頻発する `OpenSSL::SSL::SSLError` を Sentry でトラッキングするのをやめる。
大体一日で 860 回くらい発生している。

# REF
- https://docs.sentry.io/clients/ruby/config/