### PR TITLE
Make Execution of SynchronizeFeaturedCollectionWorker unique

### DIFF
--- a/app/workers/activitypub/synchronize_featured_collection_worker.rb
+++ b/app/workers/activitypub/synchronize_featured_collection_worker.rb
@@ -3,7 +3,7 @@
 class ActivityPub::SynchronizeFeaturedCollectionWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull'
+  sidekiq_options queue: 'pull', unique: :until_executed
 
   def perform(account_id)
     ActivityPub::FetchFeaturedCollectionService.new.call(Account.find(account_id))


### PR DESCRIPTION
See: https://github.com/tootsuite/mastodon/pull/7043/commits/b759b0564fc17ddf1bca06142c32d8b55578f9b4