### PR TITLE
Fixed Let's Encrypt root CA certificate expiration problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ EXPOSE 3000 4000
 WORKDIR /mastodon
 
 RUN apk -U upgrade \
+ && apk add --no-cache ca-certificates wget \
+ && update-ca-certificates \
  && apk add -t build-dependencies \
     build-base \
     icu-dev \
@@ -29,7 +31,6 @@ RUN apk -U upgrade \
     protobuf-dev \
     python \
  && apk add \
-    ca-certificates \
     ffmpeg \
     file \
     git \
@@ -40,9 +41,9 @@ RUN apk -U upgrade \
     nodejs \
     nodejs-npm \
     protobuf \
+    shared-mime-info \
     tini \
     tzdata \
- && update-ca-certificates \
  && mkdir -p /tmp/src /opt \
  && wget -O yarn.tar.gz "https://github.com/yarnpkg/yarn/releases/download/v$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
  && echo "$YARN_DOWNLOAD_SHA256 *yarn.tar.gz" | sha256sum -c - \

--- a/Dockerfile-development
+++ b/Dockerfile-development
@@ -16,6 +16,8 @@ EXPOSE 3000 4000
 WORKDIR /mastodon
 
 RUN apk -U upgrade \
+ && apk add --no-cache ca-certificates wget \
+ && update-ca-certificates \
  && apk add -t build-dependencies \
     build-base \
     icu-dev \
@@ -26,7 +28,6 @@ RUN apk -U upgrade \
     protobuf-dev \
     python \
  && apk add \
-    ca-certificates \
     ffmpeg \
     file \
     git \
@@ -37,10 +38,10 @@ RUN apk -U upgrade \
     nodejs \
     nodejs-npm \
     protobuf \
+    shared-mime-info \
     su-exec \
     tini \
     tzdata \
- && update-ca-certificates \
  && mkdir -p /tmp/src /opt \
  && wget -O yarn.tar.gz "https://github.com/yarnpkg/yarn/releases/download/v$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
  && echo "$YARN_DOWNLOAD_SHA256 *yarn.tar.gz" | sha256sum -c - \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,7 +306,9 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mimemagic (0.3.2)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)


### PR DESCRIPTION
## What

- Bump mimemagic from 0.3.2 to 0.3.10
    - container could not be built due to mimemagic (v0.3.2) being yanked.
        - https://github.com/mimemagicrb/mimemagic/issues/97
    - updated to the latest version of 0.3.x.
- Fixed Let's Encrypt root CA certificate expiration problem