### PR TITLE
Remove DST Root CA x3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,7 @@ COPY Gemfile Gemfile.lock package.json yarn.lock .yarnclean /mastodon/
 
 RUN bundle config build.nokogiri --with-iconv-lib=/usr/local/lib --with-iconv-include=/usr/local/include \
  && bundle install -j$(getconf _NPROCESSORS_ONLN) --deployment --without test development \
+ && sed -i '/DST Root CA X3/,/-----END CERTIFICATE-----/d' vendor/bundle/ruby/*/gems/aws-sdk-core-*/ca-bundle.crt \
  && yarn --pure-lockfile \
  && yarn cache clean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ WORKDIR /mastodon
 
 RUN apk -U upgrade \
  && apk add --no-cache ca-certificates wget \
- && update-ca-certificates \
  && apk add -t build-dependencies \
     build-base \
     icu-dev \
@@ -30,6 +29,13 @@ RUN apk -U upgrade \
     postgresql-dev \
     protobuf-dev \
     python \
+    sed \
+ && sed -i '/CN=DST Root CA X3/,/-----END CERTIFICATE-----/d' /etc/ssl/cert.pem \
+ && sed -i /DST_Root_CA_X3.crt/d /etc/ca-certificates.conf \
+ && rm /etc/ssl/certs/2e5ac55d.0 \
+       /etc/ssl/certs/ca-cert-DST_Root_CA_X3.pem \
+       /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt \
+ && update-ca-certificates \
  && apk add \
     ffmpeg \
     file \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,7 +172,7 @@ GEM
     erubi (1.7.0)
     et-orbi (1.0.8)
       tzinfo
-    excon (0.59.0)
+    excon (0.86.0)
     fabrication (2.18.0)
     faker (1.8.4)
       i18n (~> 0.5)


### PR DESCRIPTION
Remove the expired root CA certificate from the system and excon's certificate stores to make it possible for the app code to verify certificates from remote servers provided by Let's Encrypt.